### PR TITLE
Disable debug logging

### DIFF
--- a/client.js
+++ b/client.js
@@ -387,9 +387,9 @@ export class AuthorizationCodeGrant {
         // console.log(head)
         // console.log("---------------DEBUG requestToken------------------")
         // console.log(this.options.tokenEndpointURI);
-        for (let pair of formdata.entries()) {
-            console.log(pair[0]+ ': ' + pair[1]);
-        }
+        // for (let pair of formdata.entries()) {
+        //     console.log(pair[0]+ ': ' + pair[1]);
+        // }
 
         const response = await fetch(this.options.tokenEndpointURI, {
             method: "POST",


### PR DESCRIPTION
There was some debug logging still enabled. This PR disables it so this library doesn't clutter the console with unwanted output.